### PR TITLE
Speed up warm CatPred inference path

### DIFF
--- a/catpred/args.py
+++ b/catpred/args.py
@@ -943,6 +943,8 @@ class PredictArgs(CommonArgs):
     """Deprecated. Whether to calculate the variance of ensembles as a measure of epistemic uncertainty. If True, the variance is saved as an additional column for each target in the preds_path."""
     individual_ensemble_predictions: bool = False
     """Whether to return the predictions made by each of the individual models rather than the average of the ensemble"""
+    save_uncertainty_components: bool = False
+    """Whether to save aleatoric and epistemic uncertainty variance components when available."""
     # Uncertainty arguments
     uncertainty_method: Literal[
         'mve',

--- a/catpred/data/cache_utils.py
+++ b/catpred/data/cache_utils.py
@@ -102,7 +102,8 @@ def cache_fn(
         out = fn(t, *args, **kwargs)
 
         log(f'saving: {t} to {str(entry_path)}')
-        torch.save(out, str(entry_path))
+        cache_out = out.detach().cpu() if isinstance(out, torch.Tensor) else out
+        torch.save(cache_out, str(entry_path))
         return out
         
     return inner

--- a/catpred/inference/__init__.py
+++ b/catpred/inference/__init__.py
@@ -23,8 +23,10 @@ __all__ = [
     "PreparedInputPaths",
     "prepare_prediction_inputs",
     "run_raw_prediction",
+    "run_inprocess_prediction",
     "postprocess_predictions",
     "run_prediction_pipeline",
+    "run_inprocess_prediction_pipeline",
 ]
 
 
@@ -32,8 +34,10 @@ def __getattr__(name: str):
     if name in {
         "prepare_prediction_inputs",
         "run_raw_prediction",
+        "run_inprocess_prediction",
         "postprocess_predictions",
         "run_prediction_pipeline",
+        "run_inprocess_prediction_pipeline",
     }:
         from . import service
 

--- a/catpred/inference/backends.py
+++ b/catpred/inference/backends.py
@@ -37,8 +37,17 @@ class InferenceBackend:
 class LocalInferenceBackend(InferenceBackend):
     name = "local"
 
-    def __init__(self, repo_root: str | None = None) -> None:
+    def __init__(
+        self,
+        repo_root: str | None = None,
+        use_subprocess: bool | None = None,
+    ) -> None:
         self._repo_root = repo_root
+        self._use_subprocess = (
+            _env_flag("CATPRED_LOCAL_SUBPROCESS", default=False)
+            if use_subprocess is None
+            else use_subprocess
+        )
 
     def readiness(self) -> dict[str, Any]:
         root = Path(self._repo_root) if self._repo_root else Path.cwd()
@@ -53,17 +62,27 @@ class LocalInferenceBackend(InferenceBackend):
             "ready": len(missing) == 0,
             "missing_files": missing,
             "repo_root": str(root),
+            "mode": "subprocess" if self._use_subprocess else "in_process",
         }
 
     def predict(self, request_obj: PredictionRequest, results_dir: str) -> BackendPredictionResult:
-        from .service import run_prediction_pipeline
+        from .service import run_inprocess_prediction_pipeline, run_prediction_pipeline
 
         effective_request = request_obj
         if not request_obj.repo_root and self._repo_root:
             effective_request = replace(request_obj, repo_root=self._repo_root)
 
-        output_file = run_prediction_pipeline(effective_request, results_dir=results_dir)
-        return BackendPredictionResult(backend_name=self.name, output_file=output_file)
+        if self._use_subprocess:
+            output_file = run_prediction_pipeline(effective_request, results_dir=results_dir)
+            mode = "subprocess"
+        else:
+            output_file = run_inprocess_prediction_pipeline(effective_request, results_dir=results_dir)
+            mode = "in_process"
+        return BackendPredictionResult(
+            backend_name=self.name,
+            output_file=output_file,
+            metadata={"mode": mode},
+        )
 
 
 class ModalHTTPInferenceBackend(InferenceBackend):

--- a/catpred/inference/service.py
+++ b/catpred/inference/service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from functools import lru_cache
+import gzip
+import json
 import os
 import subprocess
 from typing import Tuple
@@ -18,6 +21,7 @@ _TARGET_COLUMNS = {
     "ki": ("log10ki_mean", "mM"),
 }
 _VALID_AAS = set("ACDEFGHIKLMNPQRSTVWY")
+_MODEL_CACHE_SIZE = max(int(os.environ.get("CATPRED_MODEL_CACHE_SIZE", "6")), 0)
 
 
 def _validate_parameter(parameter: str) -> str:
@@ -149,6 +153,162 @@ def _build_prediction_commands(
     return create_records_cmd, predict_cmd
 
 
+def _write_protein_records(input_csv: str, records_file: str) -> None:
+    df = pd.read_csv(input_csv)
+    required = {"pdbpath", "sequence"}
+    missing = required.difference(df.columns)
+    if missing:
+        raise ValueError(
+            f'Missing required column(s) in "{input_csv}": {", ".join(sorted(missing))}'
+        )
+
+    records = {}
+    conflicts = []
+    for index, row in df.iterrows():
+        row_num = index + 2
+        pdbpath = row["pdbpath"].strip() if isinstance(row["pdbpath"], str) else row["pdbpath"]
+        sequence = row["sequence"].strip() if isinstance(row["sequence"], str) else row["sequence"]
+
+        if not pdbpath:
+            raise ValueError(f'Empty "pdbpath" in row {row_num} of "{input_csv}".')
+        if not sequence:
+            raise ValueError(f'Empty "sequence" in row {row_num} of "{input_csv}".')
+
+        key = os.path.basename(pdbpath)
+        existing = records.get(key)
+        if existing is not None and existing["seq"] != sequence:
+            conflicts.append((row_num, key))
+            continue
+
+        records[key] = {"name": key, "seq": sequence}
+
+    if conflicts:
+        preview = ", ".join(
+            [f'{key} (row {row_num})' for row_num, key in conflicts[:5]]
+        )
+        raise ValueError(
+            "Found pdbpath basenames reused for different sequences. "
+            f"Each unique sequence must have a unique pdbpath. Examples: {preview}"
+        )
+
+    with gzip.open(records_file, "wt", encoding="utf-8") as handle:
+        json.dump(records, handle)
+
+
+def _build_predict_args(request: PredictionRequest, paths: PreparedInputPaths, repo_root: Path):
+    from catpred.args import PredictArgs
+
+    checkpoint_dir = Path(request.checkpoint_dir)
+    if not checkpoint_dir.is_absolute():
+        checkpoint_dir = (repo_root / checkpoint_dir).resolve()
+
+    protein_records_path = paths.records_file
+    if request.protein_records_file:
+        protein_records_path = str(
+            _resolve_existing_path(
+                request.protein_records_file,
+                repo_root=repo_root,
+                purpose="Protein records file",
+            )
+        )
+
+    args = PredictArgs()
+    args.test_path = paths.input_csv
+    args.preds_path = paths.output_csv
+    args.checkpoint_dir = str(checkpoint_dir)
+    args.uncertainty_method = "mve"
+    args.smiles_columns = ["SMILES"]
+    args.individual_ensemble_predictions = False
+    args.save_uncertainty_components = True
+    args.protein_records_path = protein_records_path
+    args.no_cuda = not request.use_gpu
+    args.process_args()
+    return args
+
+
+def _checkpoint_fingerprint(checkpoint_paths: tuple[str, ...]) -> tuple[tuple[str, int, int], ...]:
+    fingerprint = []
+    for checkpoint_path in checkpoint_paths:
+        stat = Path(checkpoint_path).stat()
+        fingerprint.append((checkpoint_path, stat.st_mtime_ns, stat.st_size))
+    return tuple(fingerprint)
+
+
+@lru_cache(maxsize=_MODEL_CACHE_SIZE)
+def _load_cached_model_objects(
+    checkpoint_paths: tuple[str, ...],
+    checkpoint_fingerprint: tuple[tuple[str, int, int], ...],
+    use_gpu: bool,
+    gpu: int | None,
+    pretrained_egnn_feats_path: str,
+):
+    del checkpoint_fingerprint  # Included in the cache key to invalidate changed checkpoints.
+
+    from catpred.args import PredictArgs
+    from catpred.train.make_predictions import load_model
+
+    args = PredictArgs()
+    args.checkpoint_paths = list(checkpoint_paths)
+    args.no_cuda = not use_gpu
+    args.gpu = gpu
+    args.pretrained_egnn_feats_path = pretrained_egnn_feats_path
+    loaded_args, train_args, models, scalers, num_tasks, task_names = load_model(
+        args=args,
+        generator=False,
+    )
+    return train_args, models, scalers, num_tasks, task_names, loaded_args.pretrained_egnn_feats_path
+
+
+def _load_model_objects_for_prediction(args):
+    from catpred.train.make_predictions import load_model
+    from catpred.utils import update_prediction_args
+
+    checkpoint_paths = tuple(args.checkpoint_paths)
+    if _MODEL_CACHE_SIZE <= 0:
+        loaded_args, train_args, models, scalers, num_tasks, task_names = load_model(
+            args=args,
+            generator=False,
+        )
+        return loaded_args, train_args, models, scalers, num_tasks, task_names
+
+    train_args, models, scalers, num_tasks, task_names, pretrained_egnn_feats_path = (
+        _load_cached_model_objects(
+            checkpoint_paths=checkpoint_paths,
+            checkpoint_fingerprint=_checkpoint_fingerprint(checkpoint_paths),
+            use_gpu=not args.no_cuda,
+            gpu=args.gpu,
+            pretrained_egnn_feats_path=args.pretrained_egnn_feats_path,
+        )
+    )
+    args.pretrained_egnn_feats_path = pretrained_egnn_feats_path
+    update_prediction_args(predict_args=args, train_args=train_args)
+    return args, train_args, models, scalers, num_tasks, task_names
+
+
+def run_inprocess_prediction(request: PredictionRequest, paths: PreparedInputPaths) -> None:
+    from catpred.train.make_predictions import make_predictions
+
+    root = _resolve_repo_root(request.repo_root)
+
+    previous_embed_cpu = os.environ.get("PROTEIN_EMBED_USE_CPU")
+    os.environ["PROTEIN_EMBED_USE_CPU"] = "0" if request.use_gpu else "1"
+    try:
+        if not request.protein_records_file:
+            _write_protein_records(paths.input_csv, paths.records_file)
+
+        args = _build_predict_args(request, paths, root)
+        model_objects = _load_model_objects_for_prediction(args)
+        make_predictions(args=args, model_objects=model_objects)
+    finally:
+        if previous_embed_cpu is None:
+            os.environ.pop("PROTEIN_EMBED_USE_CPU", None)
+        else:
+            os.environ["PROTEIN_EMBED_USE_CPU"] = previous_embed_cpu
+
+    if not os.path.exists(paths.output_csv):
+        raise FileNotFoundError(f'Prediction output file was not generated: "{paths.output_csv}"')
+
+
 def run_raw_prediction(request: PredictionRequest, paths: PreparedInputPaths) -> None:
     root = _resolve_repo_root(request.repo_root)
     create_records_cmd, predict_cmd = _build_prediction_commands(
@@ -192,37 +352,28 @@ def postprocess_predictions(parameter: str, output_csv: str) -> pd.DataFrame:
             f'Prediction output is missing required column(s): {", ".join(missing_cols)}'
         )
 
-    pred_col, pred_logcol, pred_sd_tot, pred_sd_alea, pred_sd_epi = [], [], [], [], []
+    prediction_log = df[target_col].astype(float).to_numpy()
+    unc = df[unc_col].astype(float).to_numpy()
+    alea_component_col = f"{target_col}_mve_uncal_aleatoric_var"
+    epi_component_col = f"{target_col}_mve_uncal_epistemic_var"
+    if alea_component_col in df.columns and epi_component_col in df.columns:
+        alea_unc_var = np.maximum(df[alea_component_col].astype(float).to_numpy(), 0.0)
+        epi_unc_var = np.maximum(df[epi_component_col].astype(float).to_numpy(), 0.0)
+    else:
+        model_cols = [col for col in df.columns if col.startswith(target_col) and "model_" in col]
+        if not model_cols:
+            raise ValueError(
+                "Prediction output is missing uncertainty component columns or individual "
+                f"ensemble prediction columns for {target_col}."
+            )
+        epi_unc_var = df[model_cols].astype(float).to_numpy().var(axis=1)
+        alea_unc_var = np.maximum(unc - epi_unc_var, 0.0)
 
-    for _, row in df.iterrows():
-        model_cols = [col for col in row.index if col.startswith(target_col) and "model_" in col]
-
-        unc = row[unc_col]
-        prediction_log = row[target_col]
-        prediction_linear = np.power(10, prediction_log)
-
-        if model_cols:
-            model_outs = np.array([row[col] for col in model_cols])
-            epi_unc_var = np.var(model_outs)
-        else:
-            epi_unc_var = 0.0
-
-        alea_unc_var = max(unc - epi_unc_var, 0.0)
-        epi_unc = np.sqrt(epi_unc_var)
-        alea_unc = np.sqrt(alea_unc_var)
-        total_unc = np.sqrt(max(unc, 0.0))
-
-        pred_col.append(prediction_linear)
-        pred_logcol.append(prediction_log)
-        pred_sd_tot.append(total_unc)
-        pred_sd_alea.append(alea_unc)
-        pred_sd_epi.append(epi_unc)
-
-    df[f"Prediction_({unit})"] = pred_col
-    df["Prediction_log10"] = pred_logcol
-    df["SD_total"] = pred_sd_tot
-    df["SD_aleatoric"] = pred_sd_alea
-    df["SD_epistemic"] = pred_sd_epi
+    df[f"Prediction_({unit})"] = np.power(10, prediction_log)
+    df["Prediction_log10"] = prediction_log
+    df["SD_total"] = np.sqrt(np.maximum(unc, 0.0))
+    df["SD_aleatoric"] = np.sqrt(alea_unc_var)
+    df["SD_epistemic"] = np.sqrt(epi_unc_var)
     return df
 
 
@@ -230,12 +381,30 @@ def run_prediction_pipeline(request: PredictionRequest, results_dir: str = "../r
     parameter = _validate_parameter(request.parameter)
     paths = prepare_prediction_inputs(parameter, request.input_file, request.repo_root)
     run_raw_prediction(request, paths)
+    return _write_postprocessed_predictions(parameter, paths, request.repo_root, results_dir)
 
+
+def run_inprocess_prediction_pipeline(
+    request: PredictionRequest,
+    results_dir: str = "../results",
+) -> str:
+    parameter = _validate_parameter(request.parameter)
+    paths = prepare_prediction_inputs(parameter, request.input_file, request.repo_root)
+    run_inprocess_prediction(request, paths)
+    return _write_postprocessed_predictions(parameter, paths, request.repo_root, results_dir)
+
+
+def _write_postprocessed_predictions(
+    parameter: str,
+    paths: PreparedInputPaths,
+    repo_root: str | None,
+    results_dir: str,
+) -> str:
     output_final = postprocess_predictions(parameter, paths.output_csv)
 
     results_path = Path(results_dir)
     if not results_path.is_absolute():
-        results_path = (_resolve_repo_root(request.repo_root) / results_path).resolve()
+        results_path = (_resolve_repo_root(repo_root) / results_path).resolve()
     results_path.mkdir(parents=True, exist_ok=True)
 
     out_name = Path(paths.output_csv).name

--- a/catpred/train/make_predictions.py
+++ b/catpred/train/make_predictions.py
@@ -191,6 +191,14 @@ def predict_and_save(
             estimator.individual_predictions()
         )  # shape(data, tasks, ensemble) or (data, tasks, classes, ensemble)
 
+    uncertainty_components = None
+    if (
+        args.save_uncertainty_components
+        and calibrator is None
+        and args.uncertainty_method is not None
+    ):
+        uncertainty_components = estimator.uncertainty_components()
+
     if args.evaluation_methods is not None:
 
         evaluation_data = get_data(
@@ -271,17 +279,26 @@ def predict_and_save(
             if valid_index is not None:
                 d_preds = preds[valid_index]
                 d_unc = unc[valid_index]
+                if uncertainty_components is not None:
+                    d_alea_unc = uncertainty_components[0][valid_index]
+                    d_epi_unc = uncertainty_components[1][valid_index]
                 if args.individual_ensemble_predictions:
                     ind_preds = individual_preds[valid_index]
             else:
                 d_preds = ["Invalid SMILES"] * num_tasks
                 d_unc = ["Invalid SMILES"] * num_unc_tasks
+                if uncertainty_components is not None:
+                    d_alea_unc = ["Invalid SMILES"] * num_unc_tasks
+                    d_epi_unc = ["Invalid SMILES"] * num_unc_tasks
                 if args.individual_ensemble_predictions:
                     ind_preds = [["Invalid SMILES"] * len(args.checkpoint_paths)] * num_tasks
             # Reshape multiclass to merge task and class dimension, with updated num_tasks
             if args.dataset_type == "multiclass":
                 d_preds = np.array(d_preds).reshape((num_tasks))
                 d_unc = np.array(d_unc).reshape((num_unc_tasks))
+                if uncertainty_components is not None:
+                    d_alea_unc = np.array(d_alea_unc).reshape((num_unc_tasks))
+                    d_epi_unc = np.array(d_epi_unc).reshape((num_unc_tasks))
                 if args.individual_ensemble_predictions:
                     ind_preds = ind_preds.reshape(
                         (num_tasks, len(args.checkpoint_paths))
@@ -308,6 +325,15 @@ def predict_and_save(
                 datapoint.row[pred_name] = pred
                 if args.uncertainty_method is not None:
                     datapoint.row[unc_name] = un
+            if uncertainty_components is not None:
+                component_label = (
+                    estimator.label[:-4]
+                    if estimator.label.endswith("_var")
+                    else estimator.label
+                )
+                for pred_name, alea, epi in zip(task_names, d_alea_unc, d_epi_unc):
+                    datapoint.row[f"{pred_name}_{component_label}_aleatoric_var"] = alea
+                    datapoint.row[f"{pred_name}_{component_label}_epistemic_var"] = epi
             if args.individual_ensemble_predictions:
                 for pred_name, model_preds in zip(task_names, ind_preds):
                     for idx, pred in enumerate(model_preds):

--- a/catpred/train/predict.py
+++ b/catpred/train/predict.py
@@ -8,6 +8,8 @@ from catpred.data import MoleculeDataLoader, MoleculeDataset, StandardScaler, At
 from catpred.models import MoleculeModel
 from catpred.nn_utils import activate_dropout
 
+_inference_context = getattr(torch, "inference_mode", torch.no_grad)
+
 
 def predict(
     model: MoleculeModel,
@@ -104,7 +106,7 @@ def predict(
             bond_types_batch = None
 
         # Make predictions
-        with torch.no_grad():
+        with _inference_context():
             batch_preds = model(
                 mol_batch,
                 features_batch,

--- a/catpred/uncertainty/uncertainty_estimator.py
+++ b/catpred/uncertainty/uncertainty_estimator.py
@@ -64,3 +64,13 @@ class UncertaintyEstimator:
         Return separate predictions made by each individual model in an ensemble of models.
         """
         return np.asarray(self.predictor.get_individual_preds())
+
+    def uncertainty_components(self):
+        """
+        Return aleatoric and epistemic variance components when the predictor exposes them.
+        """
+        aleatoric_vars = self.predictor.get_uncal_aleatoric_vars()
+        epistemic_vars = self.predictor.get_uncal_epistemic_vars()
+        if aleatoric_vars is None or epistemic_vars is None:
+            return None
+        return aleatoric_vars, epistemic_vars

--- a/catpred/uncertainty/uncertainty_predictor.py
+++ b/catpred/uncertainty/uncertainty_predictor.py
@@ -80,6 +80,18 @@ class UncertaintyPredictor(ABC):
         """
         return self.uncal_vars
 
+    def get_uncal_aleatoric_vars(self):
+        """
+        Return the uncalibrated aleatoric variance component when available.
+        """
+        return getattr(self, "uncal_aleatoric_vars", None)
+
+    def get_uncal_epistemic_vars(self):
+        """
+        Return the uncalibrated epistemic variance component when available.
+        """
+        return getattr(self, "uncal_epistemic_vars", None)
+
     def get_uncal_confidence(self):
         """
         Return the uncalibrated confidences for the test data
@@ -398,14 +410,16 @@ class MVEPredictor(UncertaintyPredictor):
 
         if model.is_atom_bond_targets:
             num_tasks = len(sum_preds)
-            uncal_preds, uncal_vars = [], []
+            uncal_preds, uncal_vars, aleatoric_vars, epistemic_vars = [], [], [], []
             for pred, squared, var in zip(sum_preds, sum_squared, sum_vars):
                 uncal_pred = pred / self.num_models
-                uncal_var = (var + squared) / self.num_models - np.square(
-                    pred / self.num_models
-                )
+                aleatoric_var = var / self.num_models
+                epistemic_var = squared / self.num_models - np.square(uncal_pred)
+                uncal_var = aleatoric_var + epistemic_var
                 uncal_preds.append(uncal_pred)
                 uncal_vars.append(uncal_var)
+                aleatoric_vars.append(aleatoric_var)
+                epistemic_vars.append(epistemic_var)
             self.uncal_preds = reshape_values(
                 uncal_preds,
                 self.test_data,
@@ -415,6 +429,20 @@ class MVEPredictor(UncertaintyPredictor):
             )
             self.uncal_vars = reshape_values(
                 uncal_vars,
+                self.test_data,
+                len(model.atom_targets),
+                len(model.bond_targets),
+                num_tasks,
+            )
+            self.uncal_aleatoric_vars = reshape_values(
+                aleatoric_vars,
+                self.test_data,
+                len(model.atom_targets),
+                len(model.bond_targets),
+                num_tasks,
+            )
+            self.uncal_epistemic_vars = reshape_values(
+                epistemic_vars,
                 self.test_data,
                 len(model.atom_targets),
                 len(model.bond_targets),
@@ -432,13 +460,15 @@ class MVEPredictor(UncertaintyPredictor):
                 )
         else:
             uncal_preds = sum_preds / self.num_models
-            uncal_vars = (sum_vars + sum_squared) / self.num_models - np.square(
-                sum_preds / self.num_models
-            )
+            aleatoric_vars = sum_vars / self.num_models
+            epistemic_vars = sum_squared / self.num_models - np.square(uncal_preds)
+            uncal_vars = aleatoric_vars + epistemic_vars
             self.uncal_preds, self.uncal_vars = (
                 uncal_preds.tolist(),
                 uncal_vars.tolist(),
             )
+            self.uncal_aleatoric_vars = aleatoric_vars.tolist()
+            self.uncal_epistemic_vars = epistemic_vars.tolist()
             self.individual_vars = individual_vars
             if self.individual_ensemble_predictions:
                 self.individual_preds = individual_preds.tolist()

--- a/modal_app.py
+++ b/modal_app.py
@@ -37,6 +37,12 @@ image = (
         "ipdb==0.13.13",
         "pandas-flavor>=0.6.0",
     )
+    .env(
+        {
+            "CATPRED_CACHE_PATH": "/checkpoints/esm2_embeddings",
+            "TORCH_HOME": "/checkpoints/torch",
+        }
+    )
     .add_local_python_source("catpred")
     .add_local_dir("scripts", remote_path="/root/scripts")
     .add_local_file("predict.py", remote_path="/root/predict.py")
@@ -66,20 +72,10 @@ def _safe_checkpoint_path(raw_checkpoint_dir: str) -> Path:
     return checkpoint_dir
 
 
-@app.function(
-    timeout=60 * 15,
-    cpu=4.0,
-    memory=16384,
-    volumes={"/checkpoints": checkpoints_volume},
-)
-@modal.fastapi_endpoint(method="POST", docs=True)
-def predict(
-    payload: PredictPayload,
-    authorization: Optional[str] = Header(default=None),
-) -> dict[str, Any]:
+def _predict_impl(payload: PredictPayload, authorization: Optional[str] = None) -> dict[str, Any]:
     import pandas as pd
 
-    from catpred.inference.service import run_prediction_pipeline
+    from catpred.inference.service import run_inprocess_prediction_pipeline
     from catpred.inference.types import PredictionRequest
 
     expected_token = os.environ.get("CATPRED_MODAL_AUTH_TOKEN")
@@ -127,14 +123,26 @@ def predict(
             python_executable="python",
         )
         results_dir = str((runtime_dir / "results").resolve())
-        output_file = run_prediction_pipeline(request_obj, results_dir=results_dir)
+        output_file = run_inprocess_prediction_pipeline(request_obj, results_dir=results_dir)
         output_df = pd.read_csv(output_file)
+        gpu_info: dict[str, Any] = {}
+        if payload.use_gpu:
+            import torch
+
+            gpu_info = {
+                "cuda_available": bool(torch.cuda.is_available()),
+                "cuda_device_name": (
+                    torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+                ),
+            }
 
         return {
             "output_rows": output_df.to_dict(orient="records"),
             "output_filename": Path(output_file).name,
             "row_count": int(len(output_df)),
             "backend": "modal",
+            "use_gpu": bool(payload.use_gpu),
+            "gpu": gpu_info,
         }
     except HTTPException:
         raise
@@ -144,3 +152,69 @@ def predict(
         input_path = Path(tmp_input_path)
         if input_path.exists():
             input_path.unlink()
+
+
+@app.function(
+    timeout=60 * 15,
+    cpu=4.0,
+    memory=16384,
+    volumes={"/checkpoints": checkpoints_volume},
+)
+@modal.fastapi_endpoint(method="POST", docs=True)
+def predict(
+    payload: PredictPayload,
+    authorization: Optional[str] = Header(default=None),
+) -> dict[str, Any]:
+    return _predict_impl(payload, authorization=authorization)
+
+
+@app.function(
+    timeout=60 * 15,
+    cpu=4.0,
+    memory=16384,
+    gpu="T4",
+    volumes={"/checkpoints": checkpoints_volume},
+)
+def predict_gpu(payload: dict[str, Any]) -> dict[str, Any]:
+    gpu_payload = PredictPayload(**payload)
+    gpu_payload.use_gpu = True
+    return _predict_impl(gpu_payload)
+
+
+@app.local_entrypoint()
+def gpu_smoke(
+    parameter: str = "kcat",
+    input_file: str = "demo/batch_kcat.csv",
+    limit: int = 1,
+) -> None:
+    import json
+
+    import pandas as pd
+
+    rows = pd.read_csv(input_file).head(limit).to_dict(orient="records")
+    result = predict_gpu.remote(
+        {
+            "parameter": parameter,
+            "checkpoint_dir": parameter,
+            "use_gpu": True,
+            "input_rows": rows,
+            "input_filename": Path(input_file).name,
+        }
+    )
+    output_rows = result.get("output_rows", [])
+    preview = output_rows[0] if output_rows else {}
+    print(
+        json.dumps(
+            {
+                "backend": result.get("backend"),
+                "use_gpu": result.get("use_gpu"),
+                "parameter": parameter,
+                "row_count": result.get("row_count"),
+                "output_filename": result.get("output_filename"),
+                "gpu": result.get("gpu"),
+                "preview_keys": list(preview)[:8],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import statistics
+import sys
+import time
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _time_runs(
+    label: str,
+    runner: Callable[[Any, str], str],
+    request: Any,
+    results_dir: Path,
+    warmup: int,
+    runs: int,
+) -> list[float]:
+    for index in range(warmup):
+        runner(request, str(results_dir / label / f"warmup_{index}"))
+
+    timings = []
+    for index in range(runs):
+        started = time.perf_counter()
+        runner(request, str(results_dir / label / f"run_{index}"))
+        timings.append(time.perf_counter() - started)
+    return timings
+
+
+def _summary(timings: list[float]) -> dict[str, float]:
+    return {
+        "min_seconds": min(timings),
+        "median_seconds": statistics.median(timings),
+        "max_seconds": max(timings),
+        "mean_seconds": statistics.mean(timings),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark CatPred legacy subprocess inference against the warm "
+            "in-process inference path."
+        )
+    )
+    parser.add_argument("--parameter", choices=["kcat", "km", "ki"], required=True)
+    parser.add_argument("--input-file", required=True)
+    parser.add_argument("--checkpoint-dir", required=True)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--results-dir", default="benchmark_results")
+    parser.add_argument("--python-executable", default=sys.executable)
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--use-gpu", action="store_true")
+    parser.add_argument(
+        "--skip-subprocess",
+        action="store_true",
+        help="Only benchmark the in-process path.",
+    )
+    parser.add_argument(
+        "--json-out",
+        default=None,
+        help="Optional path to write benchmark results as JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.runs < 1:
+        raise ValueError("--runs must be at least 1.")
+    if args.warmup < 0:
+        raise ValueError("--warmup cannot be negative.")
+
+    from catpred.inference.service import (
+        run_inprocess_prediction_pipeline,
+        run_prediction_pipeline,
+    )
+    from catpred.inference.types import PredictionRequest
+
+    request = PredictionRequest(
+        parameter=args.parameter,
+        input_file=args.input_file,
+        checkpoint_dir=args.checkpoint_dir,
+        use_gpu=args.use_gpu,
+        repo_root=args.repo_root,
+        python_executable=args.python_executable,
+    )
+    results_dir = Path(args.results_dir).resolve()
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    report: dict[str, object] = {
+        "parameter": args.parameter,
+        "input_file": str(Path(args.input_file).resolve()),
+        "checkpoint_dir": str(Path(args.checkpoint_dir).resolve()),
+        "runs": args.runs,
+        "warmup": args.warmup,
+        "use_gpu": args.use_gpu,
+    }
+
+    if not args.skip_subprocess:
+        subprocess_timings = _time_runs(
+            label="subprocess",
+            runner=run_prediction_pipeline,
+            request=request,
+            results_dir=results_dir,
+            warmup=0,
+            runs=args.runs,
+        )
+        report["subprocess"] = _summary(subprocess_timings)
+
+    inprocess_timings = _time_runs(
+        label="in_process",
+        runner=run_inprocess_prediction_pipeline,
+        request=request,
+        results_dir=results_dir,
+        warmup=args.warmup,
+        runs=args.runs,
+    )
+    report["in_process"] = _summary(inprocess_timings)
+
+    if "subprocess" in report:
+        subprocess_median = report["subprocess"]["median_seconds"]  # type: ignore[index]
+        inprocess_median = report["in_process"]["median_seconds"]  # type: ignore[index]
+        report["median_speedup"] = subprocess_median / inprocess_median
+        report["median_latency_reduction_percent"] = (
+            (subprocess_median - inprocess_median) / subprocess_median * 100.0
+        )
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.json_out:
+        Path(args.json_out).write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_inference_fast_path.py
+++ b/tests/test_inference_fast_path.py
@@ -1,0 +1,176 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def install_import_stubs() -> None:
+    pandas = types.ModuleType("pandas")
+    pandas.DataFrame = object
+    sys.modules.setdefault("pandas", pandas)
+
+    numpy = types.ModuleType("numpy")
+    sys.modules.setdefault("numpy", numpy)
+
+    rdkit = types.ModuleType("rdkit")
+    chem = types.ModuleType("rdkit.Chem")
+    rdkit.Chem = chem
+    sys.modules.setdefault("rdkit", rdkit)
+    sys.modules.setdefault("rdkit.Chem", chem)
+
+
+install_import_stubs()
+
+from catpred.inference.backends import LocalInferenceBackend
+from catpred.inference.types import PredictionRequest
+from catpred.inference import service
+
+
+class LocalInferenceBackendTests(unittest.TestCase):
+    def _request(self) -> PredictionRequest:
+        return PredictionRequest(
+            parameter="kcat",
+            input_file="input.csv",
+            checkpoint_dir="checkpoints/kcat",
+            repo_root=".",
+        )
+
+    def test_local_backend_uses_inprocess_runner_by_default(self) -> None:
+        backend = LocalInferenceBackend(use_subprocess=False)
+        with patch(
+            "catpred.inference.service.run_inprocess_prediction_pipeline",
+            return_value="/tmp/out.csv",
+        ) as fast_runner, patch(
+            "catpred.inference.service.run_prediction_pipeline",
+            return_value="/tmp/slow.csv",
+        ) as subprocess_runner:
+            result = backend.predict(self._request(), results_dir="/tmp/results")
+
+        self.assertEqual(result.output_file, "/tmp/out.csv")
+        self.assertEqual(result.metadata["mode"], "in_process")
+        fast_runner.assert_called_once()
+        subprocess_runner.assert_not_called()
+
+    def test_local_backend_can_use_subprocess_compatibility_mode(self) -> None:
+        backend = LocalInferenceBackend(use_subprocess=True)
+        with patch(
+            "catpred.inference.service.run_inprocess_prediction_pipeline",
+            return_value="/tmp/out.csv",
+        ) as fast_runner, patch(
+            "catpred.inference.service.run_prediction_pipeline",
+            return_value="/tmp/slow.csv",
+        ) as subprocess_runner:
+            result = backend.predict(self._request(), results_dir="/tmp/results")
+
+        self.assertEqual(result.output_file, "/tmp/slow.csv")
+        self.assertEqual(result.metadata["mode"], "subprocess")
+        subprocess_runner.assert_called_once()
+        fast_runner.assert_not_called()
+
+
+class ModelCacheTests(unittest.TestCase):
+    def setUp(self) -> None:
+        service._load_cached_model_objects.cache_clear()
+
+    def test_model_objects_are_reused_for_unchanged_checkpoints(self) -> None:
+        load_calls = []
+
+        class FakePredictArgs:
+            def __init__(self) -> None:
+                self.checkpoint_paths = []
+                self.no_cuda = True
+                self.gpu = None
+                self.pretrained_egnn_feats_path = ""
+
+        fake_args_module = types.ModuleType("catpred.args")
+        fake_args_module.PredictArgs = FakePredictArgs
+
+        fake_train_module = types.ModuleType("catpred.train.make_predictions")
+
+        def fake_load_model(args, generator):
+            load_calls.append((tuple(args.checkpoint_paths), generator))
+            args.pretrained_egnn_feats_path = "resolved-feats.pt"
+            return args, "train_args", ["model"], ["scaler"], 1, ["task"]
+
+        fake_train_module.load_model = fake_load_model
+
+        fake_utils_module = types.ModuleType("catpred.utils")
+
+        def fake_update_prediction_args(predict_args, train_args):
+            predict_args.updated_from = train_args
+
+        fake_utils_module.update_prediction_args = fake_update_prediction_args
+
+        with TemporaryDirectory() as tmp_dir:
+            checkpoint = Path(tmp_dir) / "model.pt"
+            checkpoint.write_text("checkpoint", encoding="utf-8")
+            first_args = SimpleNamespace(
+                checkpoint_paths=[str(checkpoint)],
+                no_cuda=True,
+                gpu=None,
+                pretrained_egnn_feats_path="",
+            )
+            second_args = SimpleNamespace(
+                checkpoint_paths=[str(checkpoint)],
+                no_cuda=True,
+                gpu=None,
+                pretrained_egnn_feats_path="",
+            )
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "catpred.args": fake_args_module,
+                    "catpred.train.make_predictions": fake_train_module,
+                    "catpred.utils": fake_utils_module,
+                },
+            ):
+                first = service._load_model_objects_for_prediction(first_args)
+                second = service._load_model_objects_for_prediction(second_args)
+
+        self.assertEqual(len(load_calls), 1)
+        self.assertEqual(first[2], ["model"])
+        self.assertEqual(second[2], ["model"])
+        self.assertEqual(first_args.updated_from, "train_args")
+        self.assertEqual(second_args.updated_from, "train_args")
+
+
+class FastPredictArgsTests(unittest.TestCase):
+    def test_fast_predict_args_save_components_without_individual_predictions(self) -> None:
+        class FakePredictArgs:
+            def process_args(self) -> None:
+                self.checkpoint_paths = [str(Path(self.checkpoint_dir) / "model.pt")]
+
+        fake_args_module = types.ModuleType("catpred.args")
+        fake_args_module.PredictArgs = FakePredictArgs
+
+        with TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            checkpoint_dir = repo_root / "checkpoints" / "kcat"
+            checkpoint_dir.mkdir(parents=True)
+            paths = service.PreparedInputPaths(
+                input_csv=str(repo_root / "input.csv"),
+                records_file=str(repo_root / "input.json.gz"),
+                output_csv=str(repo_root / "output.csv"),
+            )
+            request = PredictionRequest(
+                parameter="kcat",
+                input_file=str(repo_root / "input.csv"),
+                checkpoint_dir="checkpoints/kcat",
+                repo_root=str(repo_root),
+            )
+
+            with patch.dict(sys.modules, {"catpred.args": fake_args_module}):
+                args = service._build_predict_args(request, paths, repo_root)
+
+        self.assertFalse(args.individual_ensemble_predictions)
+        self.assertTrue(args.save_uncertainty_components)
+        self.assertEqual(args.uncertainty_method, "mve")
+        self.assertEqual(args.smiles_columns, ["SMILES"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postprocess_predictions.py
+++ b/tests/test_postprocess_predictions.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def _has_module(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ValueError:
+        return False
+
+
+HAS_PANDAS_NUMPY = _has_module("pandas") and _has_module("numpy")
+
+
+@unittest.skipUnless(HAS_PANDAS_NUMPY, "pandas and numpy are required")
+class PostprocessPredictionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        rdkit = types.ModuleType("rdkit")
+        chem = types.ModuleType("rdkit.Chem")
+        rdkit.Chem = chem
+        sys.modules.setdefault("rdkit", rdkit)
+        sys.modules.setdefault("rdkit.Chem", chem)
+
+    def test_prefers_exact_uncertainty_component_columns(self) -> None:
+        import pandas as pd
+
+        from catpred.inference.service import postprocess_predictions
+
+        with TemporaryDirectory() as tmp_dir:
+            output_path = Path(tmp_dir) / "preds.csv"
+            pd.DataFrame(
+                [
+                    {
+                        "SMILES": "C",
+                        "log10kcat_max": 1.0,
+                        "log10kcat_max_mve_uncal_var": 0.09,
+                        "log10kcat_max_mve_uncal_aleatoric_var": 0.05,
+                        "log10kcat_max_mve_uncal_epistemic_var": 0.04,
+                    }
+                ]
+            ).to_csv(output_path, index=False)
+
+            result = postprocess_predictions("kcat", str(output_path))
+
+        self.assertAlmostEqual(result["Prediction_(s^(-1))"].iloc[0], 10.0)
+        self.assertAlmostEqual(result["SD_total"].iloc[0], 0.3)
+        self.assertAlmostEqual(result["SD_aleatoric"].iloc[0], 0.05 ** 0.5)
+        self.assertAlmostEqual(result["SD_epistemic"].iloc[0], 0.2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a warm in-process inference path that reuses loaded checkpoint models/scalers instead of spawning a fresh Python process for each request.
- Preserve exact MVE uncertainty component outputs without requiring per-model ensemble prediction columns.
- Route local and Modal inference through the fast path by default, while keeping subprocess compatibility via `CATPRED_LOCAL_SUBPROCESS=1`.
- Add a benchmark CLI and focused tests for routing, model-cache reuse, uncertainty postprocessing, and ESM batching/cache behavior.
- Add Modal GPU smoke support and persist ESM/Torch caches on the Modal checkpoint volume; ESM cache entries are saved as CPU tensors so CPU and GPU workers can both reuse them.
- Batch uncached unique ESM sequences before dataset construction. Defaults are conservative on CPU (`CATPRED_ESM_BATCH_SIZE=1`) and batched on GPU (`4`), with recursive OOM fallback and an env override.

## Benchmarks
Local macOS CPU, conda env `esm`, 2-row demo inputs, production checkpoints, 3 measured runs with 1 in-process warmup:

| Parameter | Legacy subprocess median | Warm in-process median | Median speedup | Latency reduction |
| --- | ---: | ---: | ---: | ---: |
| `kcat` | 2.6674 s | 0.2906 s | 9.18x | 89.10% |
| `km` | 2.9151 s | 0.3042 s | 9.58x | 89.57% |
| `ki` | 2.5334 s | 0.0614 s | 41.24x | 97.57% |

Output equivalence vs legacy subprocess was verified for predictions and uncertainty fields:
- `kcat`: max abs diff `1.11e-16`
- `km`: max abs diff `3.89e-16`
- `ki`: max abs diff `2.22e-16`

Additional ESM-cache checks:
- Fresh local CPU ESM-cache run for 2-row `kcat`, batch size 1: `7.733 s`, matching prior subprocess output exactly up to existing `SD_aleatoric` noise (`1.11e-16`).
- Fresh local CPU ESM-cache run for 2-row `kcat`, batch size 4: `10.564 s`; this was slower for short CPU rows, so CPU defaults to 1.
- Fresh Modal GPU smoke for 2-row `kcat`: Tesla T4, `cuda_available=true`, `row_count=2`, approximately `16 s`, and wrote 2 ESM cache entries.

Modal GPU smoke verification:
- `kcat`, `km`, and `ki` each completed 1-row inference on Tesla T4 with `cuda_available=true`.
- Returned exact uncertainty component columns such as `*_mve_uncal_aleatoric_var` and `*_mve_uncal_epistemic_var`.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test_inference_fast_path.py tests/test_postprocess_predictions.py tests/test_esm_batching.py -v`
- `PYTHONDONTWRITEBYTECODE=1 conda run -n esm python -m unittest tests/test_postprocess_predictions.py tests/test_esm_batching.py -v`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile catpred/args.py catpred/data/cache_utils.py catpred/data/esm_utils.py catpred/data/utils.py catpred/inference/__init__.py catpred/inference/backends.py catpred/inference/service.py catpred/train/make_predictions.py catpred/train/predict.py catpred/uncertainty/uncertainty_estimator.py catpred/uncertainty/uncertainty_predictor.py modal_app.py scripts/benchmark_inference.py tests/test_inference_fast_path.py tests/test_postprocess_predictions.py tests/test_esm_batching.py`
- `PYTHONDONTWRITEBYTECODE=1 conda run -n esm python scripts/benchmark_inference.py --help`

## Notes
This now covers the first deeper ESM pass: persistent caches, CPU/GPU-shareable cache values, unique-sequence materialization, GPU batching, and OOM fallback. A larger future step would be a dedicated long-lived ESM service/worker for high-throughput API deployments.
