### PR TITLE
Cache and deduplicate repeated inference requests

### DIFF
--- a/catpred/data/cache_utils.py
+++ b/catpred/data/cache_utils.py
@@ -28,6 +28,37 @@ def md5_hash_fn(s):
     encoded = s.encode('utf-8')
     return hashlib.md5(encoded).hexdigest()
 
+
+def cache_entry_path(path='', cache_key=None, hash_fn=md5_hash_fn, name=None):
+    (CACHE_PATH / path).mkdir(parents=True, exist_ok=True)
+    if name is None:
+        key = hash_fn(cache_key)
+    else:
+        key = name
+    return CACHE_PATH / path / f'{key}.pt'
+
+
+def load_cache_value(path='', cache_key=None, *, purpose="cache entry", hash_fn=md5_hash_fn, name=None, map_location=None):
+    entry_path = cache_entry_path(path=path, cache_key=cache_key, hash_fn=hash_fn, name=name)
+    if not entry_path.exists():
+        return None
+
+    log(f'cache hit: fetching {cache_key} from {str(entry_path)}')
+    return load_torch_artifact(
+        str(entry_path),
+        purpose=purpose,
+        map_location=map_location,
+        roots=[CACHE_PATH],
+    )
+
+
+def save_cache_value(value, path='', cache_key=None, *, hash_fn=md5_hash_fn, name=None):
+    entry_path = cache_entry_path(path=path, cache_key=cache_key, hash_fn=hash_fn, name=name)
+    log(f'saving: {cache_key} to {str(entry_path)}')
+    cache_value = value.detach().cpu() if isinstance(value, torch.Tensor) else value
+    torch.save(cache_value, str(entry_path))
+    return entry_path
+
 # run once function
 
 GLOBAL_RUN_RECORDS = dict()
@@ -83,27 +114,20 @@ def cache_fn(
         if clear:
             clear_cache_folder_()
 
-        if name is None: 
-            cache_str = __cache_key if exists(__cache_key) else t
-            key = hash_fn(cache_str)
-        else:
-            key = name
-
-        entry_path = CACHE_PATH / path / f'{key}.pt'
-
-        if entry_path.exists():
-            log(f'cache hit: fetching {t} from {str(entry_path)}')
-            return load_torch_artifact(
-                str(entry_path),
-                purpose="esm cache entry",
-                roots=[CACHE_PATH],
-            )
+        cache_str = __cache_key if exists(__cache_key) else t
+        cached = load_cache_value(
+            path=path,
+            cache_key=cache_str,
+            purpose="esm cache entry",
+            hash_fn=hash_fn,
+            name=name,
+        )
+        if cached is not None:
+            return cached
 
         out = fn(t, *args, **kwargs)
 
-        log(f'saving: {t} to {str(entry_path)}')
-        cache_out = out.detach().cpu() if isinstance(out, torch.Tensor) else out
-        torch.save(cache_out, str(entry_path))
+        save_cache_value(out, path=path, cache_key=cache_str, hash_fn=hash_fn, name=name)
         return out
         
     return inner

--- a/catpred/data/esm_utils.py
+++ b/catpred/data/esm_utils.py
@@ -3,7 +3,7 @@ import os
 from functools import partial
 import esm
 from torch.nn.utils.rnn import pad_sequence
-from .cache_utils import cache_fn, run_once
+from .cache_utils import cache_fn, load_cache_value, run_once, save_cache_value
 
 def exists(val):
     return val is not None
@@ -63,6 +63,11 @@ def calc_protein_representations_with_subunits(proteins, get_repr_fn, *, device)
 
 ESM_MAX_LENGTH = 2048
 ESM_EMBED_DIM = 1280
+ESM_CACHE_PATH = 'esm/proteins'
+DEFAULT_ESM_BATCH_SIZE = max(
+    int(os.getenv("CATPRED_ESM_BATCH_SIZE", "1" if PROTEIN_EMBED_USE_CPU else "4")),
+    1,
+)
 
 INT_TO_AA_STR_MAP = {
     0: '<cls>',
@@ -154,6 +159,86 @@ def get_single_esm_repr(protein_str):
     representation = token_representations[0][1 : len(protein_str) + 1]
     return representation
 
+
+def _run_esm_batch(protein_strs):
+    init_esm()
+    model, batch_converter = GLOBAL_VARIABLES['model']
+
+    data = [(f'protein_{index}', protein_str) for index, protein_str in enumerate(protein_strs)]
+    batch_labels, batch_strs, batch_tokens = batch_converter(data)
+
+    if batch_tokens.shape[1] > ESM_MAX_LENGTH:
+        print(f'warning max length protein esm')
+
+    batch_tokens = batch_tokens[:, :ESM_MAX_LENGTH]
+
+    if not PROTEIN_EMBED_USE_CPU:
+        batch_tokens = batch_tokens.to(next(model.parameters()).device)
+
+    with torch.no_grad():
+        results = model(batch_tokens, repr_layers=[33])
+
+    token_representations = results['representations'][33]
+    representations = []
+    max_residue_tokens = ESM_MAX_LENGTH - 1
+    for index, protein_str in enumerate(protein_strs):
+        representation_length = min(len(protein_str), max_residue_tokens)
+        representations.append(
+            token_representations[index][1 : representation_length + 1].detach()
+        )
+    return representations
+
+
+def _run_esm_batch_with_fallback(protein_strs):
+    try:
+        return _run_esm_batch(protein_strs)
+    except RuntimeError as e:
+        if 'out of memory' not in str(e) or len(protein_strs) == 1:
+            raise e
+        print('| WARNING: ran out of memory, retrying smaller ESM batches')
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        midpoint = len(protein_strs) // 2
+        return (
+            _run_esm_batch_with_fallback(protein_strs[:midpoint])
+            + _run_esm_batch_with_fallback(protein_strs[midpoint:])
+        )
+
+
+def get_many_esm_reprs(proteins, device='cpu', batch_size=None):
+    if isinstance(proteins, torch.Tensor):
+        proteins = tensor_to_aa_str(proteins)
+
+    batch_size = max(int(batch_size or DEFAULT_ESM_BATCH_SIZE), 1)
+    ordered_unique_proteins = list(dict.fromkeys(proteins))
+    representations_by_sequence = {}
+    uncached_proteins = []
+
+    for protein_str in ordered_unique_proteins:
+        cached = load_cache_value(
+            path=ESM_CACHE_PATH,
+            cache_key=protein_str,
+            purpose="esm cache entry",
+            map_location='cpu',
+        )
+        if cached is None:
+            uncached_proteins.append(protein_str)
+        else:
+            representations_by_sequence[protein_str] = cached
+
+    for start in range(0, len(uncached_proteins), batch_size):
+        batch = uncached_proteins[start : start + batch_size]
+        batch_representations = _run_esm_batch_with_fallback(batch)
+        for protein_str, representation in zip(batch, batch_representations):
+            save_cache_value(representation, path=ESM_CACHE_PATH, cache_key=protein_str)
+            representations_by_sequence[protein_str] = representation
+
+    return {
+        protein_str: representations_by_sequence[protein_str].to(device)
+        for protein_str in ordered_unique_proteins
+    }
+
+
 def get_esm_repr(proteins, name, device):
     if isinstance(proteins, torch.Tensor):
         proteins = tensor_to_aa_str(proteins)
@@ -161,7 +246,7 @@ def get_esm_repr(proteins, name, device):
     # Cache by sequence content to avoid collisions when different proteins
     # are accidentally given the same pdb/name identifier.
     _ = name
-    get_protein_repr_fn = cache_fn(get_single_esm_repr, path='esm/proteins')
+    get_protein_repr_fn = cache_fn(get_single_esm_repr, path=ESM_CACHE_PATH)
 
     return calc_protein_representations_with_subunits([proteins], get_protein_repr_fn, device=device)
 
@@ -208,6 +293,7 @@ PROTEIN_REPR_CONFIG = {
     'esm': {
         'dim': ESM_EMBED_DIM,
         'fn': get_esm_repr,
+        'batch_fn': get_many_esm_reprs,
         'tokenizer': get_esm_tokens,
     }
 }

--- a/catpred/data/utils.py
+++ b/catpred/data/utils.py
@@ -58,6 +58,30 @@ def _load_protein_records(protein_records_path: str):
                 "Expected a JSON mapping in .json or .json.gz format."
             ) from plain_err
 
+
+def _populate_missing_esm2_features(
+        protein_records,
+        sequence_feat_getter,
+        sequence_batch_getter=None):
+    if not protein_records:
+        return
+
+    unique_sequences = list(dict.fromkeys(record['seq'] for record in protein_records))
+    if sequence_batch_getter is not None:
+        features_by_sequence = sequence_batch_getter(unique_sequences, device='cpu')
+        for record in protein_records:
+            record['esm2_feats'] = features_by_sequence[record['seq']]
+        return
+
+    features_by_sequence = {}
+    for record in protein_records:
+        sequence = record['seq']
+        if sequence not in features_by_sequence:
+            sequence_features, _ = sequence_feat_getter(sequence, name=record['name'], device='cpu')
+            features_by_sequence[sequence] = sequence_features[0]  # batch dim
+        record['esm2_feats'] = features_by_sequence[sequence]
+
+
 def get_header(path: str) -> List[str]:
     """
     Returns the header of a data CSV file.
@@ -509,7 +533,9 @@ def get_data(path: str,
 
     # Load sequence features
     if not protein_records is None:
-        sequence_feat_getter = get_protein_embedder('esm')['fn']
+        protein_embedder = get_protein_embedder('esm')
+        sequence_feat_getter = protein_embedder['fn']
+        sequence_batch_getter = protein_embedder.get('batch_fn')
                  
     # Load data
     smoke_test_counter = 0
@@ -523,6 +549,7 @@ def get_data(path: str,
 
         all_smiles, all_sequences, all_targets, all_atom_targets, all_bond_targets, all_rows, all_features, all_phase_features, all_constraints_data, all_raw_constraints_data, all_weights, all_gt, all_lt = [], [], [], [], [], [], [], [], [], [], [], [], []
         all_protein_records = []
+        missing_esm2_records = []
         for i, row in enumerate(tqdm(reader)):
             smoke_test_counter+=1
             if args.smoke_test: 
@@ -571,12 +598,7 @@ def get_data(path: str,
                             roots=[esm2_feats_path.parent],
                         )
                     else:
-                        sequence_features, _ = sequence_feat_getter(
-                            protein_record['seq'],
-                            name=pdbname,
-                            device='cpu'
-                        )
-                        protein_record['esm2_feats'] = sequence_features[0]  # batch dim
+                        missing_esm2_records.append(protein_record)
                 
             targets, atom_targets, bond_targets = [], [], []
             for column in target_columns:
@@ -649,6 +671,13 @@ def get_data(path: str,
 
             if len(all_smiles) >= max_data_size:
                 break
+
+        if protein_records is not None:
+            _populate_missing_esm2_features(
+                missing_esm2_records,
+                sequence_feat_getter=sequence_feat_getter,
+                sequence_batch_getter=sequence_batch_getter,
+            )
 
         atom_features = None
         atom_descriptors = None

--- a/catpred/inference/service.py
+++ b/catpred/inference/service.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from pathlib import Path
 from functools import lru_cache
 import gzip
+import hashlib
 import json
 import os
 import subprocess
+import threading
 from typing import Tuple
 
 import numpy as np
@@ -22,6 +25,9 @@ _TARGET_COLUMNS = {
 }
 _VALID_AAS = set("ACDEFGHIKLMNPQRSTVWY")
 _MODEL_CACHE_SIZE = max(int(os.environ.get("CATPRED_MODEL_CACHE_SIZE", "6")), 0)
+_PREDICTION_CACHE_SIZE = max(int(os.environ.get("CATPRED_PREDICTION_CACHE_SIZE", "128")), 0)
+_PREDICTION_CACHE: OrderedDict[tuple, str] = OrderedDict()
+_PREDICTION_CACHE_LOCK = threading.Lock()
 
 
 def _validate_parameter(parameter: str) -> str:
@@ -285,6 +291,89 @@ def _expand_deduplicated_prediction_output(
     expanded_df.to_csv(original_paths.output_csv, index=False)
 
 
+def _file_digest(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _prediction_checkpoint_paths(checkpoint_dir: str, repo_root: Path) -> tuple[str, ...]:
+    checkpoint_path = Path(checkpoint_dir)
+    if not checkpoint_path.is_absolute():
+        checkpoint_path = (repo_root / checkpoint_path).resolve()
+    if checkpoint_path.is_file():
+        return (str(checkpoint_path),)
+    if not checkpoint_path.is_dir():
+        raise FileNotFoundError(f'Checkpoint directory not found: "{checkpoint_path}"')
+    model_paths = sorted(str(path.resolve()) for path in checkpoint_path.rglob("model.pt"))
+    if not model_paths:
+        raise FileNotFoundError(f'No model.pt checkpoints found in "{checkpoint_path}"')
+    return tuple(model_paths)
+
+
+def _prediction_cache_key(
+    parameter: str,
+    request: PredictionRequest,
+    paths: PreparedInputPaths,
+    repo_root: Path,
+) -> tuple:
+    protein_records_digest = None
+    if request.protein_records_file:
+        protein_records_path = _resolve_existing_path(
+            request.protein_records_file,
+            repo_root=repo_root,
+            purpose="Protein records file",
+        )
+        protein_records_digest = _file_digest(str(protein_records_path))
+
+    checkpoint_paths = _prediction_checkpoint_paths(request.checkpoint_dir, repo_root)
+    return (
+        parameter,
+        bool(request.use_gpu),
+        _file_digest(paths.input_csv),
+        protein_records_digest,
+        _checkpoint_fingerprint(checkpoint_paths),
+    )
+
+
+def _prediction_cache_get(cache_key: tuple) -> str | None:
+    if _PREDICTION_CACHE_SIZE <= 0:
+        return None
+    with _PREDICTION_CACHE_LOCK:
+        cached = _PREDICTION_CACHE.get(cache_key)
+        if cached is not None:
+            _PREDICTION_CACHE.move_to_end(cache_key)
+        return cached
+
+
+def _prediction_cache_put(cache_key: tuple, csv_text: str) -> None:
+    if _PREDICTION_CACHE_SIZE <= 0:
+        return
+    with _PREDICTION_CACHE_LOCK:
+        _PREDICTION_CACHE[cache_key] = csv_text
+        _PREDICTION_CACHE.move_to_end(cache_key)
+        while len(_PREDICTION_CACHE) > _PREDICTION_CACHE_SIZE:
+            _PREDICTION_CACHE.popitem(last=False)
+
+
+def _write_cached_prediction(
+    cached_csv: str,
+    paths: PreparedInputPaths,
+    repo_root: str | None,
+    results_dir: str,
+) -> str:
+    results_path = Path(results_dir)
+    if not results_path.is_absolute():
+        results_path = (_resolve_repo_root(repo_root) / results_path).resolve()
+    results_path.mkdir(parents=True, exist_ok=True)
+
+    final_output = results_path / Path(paths.output_csv).name
+    final_output.write_text(cached_csv, encoding="utf-8")
+    return str(final_output)
+
+
 @lru_cache(maxsize=_MODEL_CACHE_SIZE)
 def _load_cached_model_objects(
     checkpoint_paths: tuple[str, ...],
@@ -441,6 +530,12 @@ def run_inprocess_prediction_pipeline(
 ) -> str:
     parameter = _validate_parameter(request.parameter)
     paths = prepare_prediction_inputs(parameter, request.input_file, request.repo_root)
+    root = _resolve_repo_root(request.repo_root)
+    cache_key = _prediction_cache_key(parameter, request, paths, root)
+    cached_csv = _prediction_cache_get(cache_key)
+    if cached_csv is not None:
+        return _write_cached_prediction(cached_csv, paths, request.repo_root, results_dir)
+
     if request.protein_records_file:
         prediction_paths, was_deduplicated = paths, False
     else:
@@ -448,7 +543,9 @@ def run_inprocess_prediction_pipeline(
     run_inprocess_prediction(request, prediction_paths)
     if was_deduplicated:
         _expand_deduplicated_prediction_output(paths, prediction_paths)
-    return _write_postprocessed_predictions(parameter, paths, request.repo_root, results_dir)
+    final_output = _write_postprocessed_predictions(parameter, paths, request.repo_root, results_dir)
+    _prediction_cache_put(cache_key, Path(final_output).read_text(encoding="utf-8"))
+    return final_output
 
 
 def _write_postprocessed_predictions(

--- a/catpred/inference/service.py
+++ b/catpred/inference/service.py
@@ -234,6 +234,57 @@ def _checkpoint_fingerprint(checkpoint_paths: tuple[str, ...]) -> tuple[tuple[st
     return tuple(fingerprint)
 
 
+def _deduplicate_prediction_input(paths: PreparedInputPaths) -> tuple[PreparedInputPaths, bool]:
+    input_df = pd.read_csv(paths.input_csv)
+    key_columns = ["SMILES", "sequence"]
+    if any(column not in input_df.columns for column in key_columns):
+        return paths, False
+
+    unique_df = input_df.drop_duplicates(subset=key_columns, keep="first")
+    if len(unique_df) == len(input_df):
+        return paths, False
+
+    input_path = Path(paths.input_csv)
+    unique_input_csv = input_path.with_name(f"{input_path.stem}_unique{input_path.suffix}")
+    unique_output_csv = unique_input_csv.with_name(f"{unique_input_csv.with_suffix('').name}_output.csv")
+    unique_df.to_csv(unique_input_csv, index=False)
+    return (
+        PreparedInputPaths(
+            input_csv=str(unique_input_csv),
+            records_file=paths.records_file,
+            output_csv=str(unique_output_csv),
+        ),
+        True,
+    )
+
+
+def _expand_deduplicated_prediction_output(
+    original_paths: PreparedInputPaths,
+    deduplicated_paths: PreparedInputPaths,
+) -> None:
+    full_df = pd.read_csv(original_paths.input_csv)
+    unique_input_df = pd.read_csv(deduplicated_paths.input_csv)
+    unique_output_df = pd.read_csv(deduplicated_paths.output_csv)
+    key_columns = ["SMILES", "sequence"]
+    prediction_columns = [
+        column for column in unique_output_df.columns if column not in unique_input_df.columns
+    ]
+
+    if not prediction_columns:
+        raise ValueError("Deduplicated prediction output did not contain prediction columns.")
+
+    prediction_lookup = unique_output_df[key_columns + prediction_columns].drop_duplicates(
+        subset=key_columns,
+        keep="first",
+    )
+    expanded_df = full_df.merge(prediction_lookup, on=key_columns, how="left", sort=False)
+
+    if expanded_df[prediction_columns].isnull().any().any():
+        raise ValueError("Failed to expand deduplicated predictions to all input rows.")
+
+    expanded_df.to_csv(original_paths.output_csv, index=False)
+
+
 @lru_cache(maxsize=_MODEL_CACHE_SIZE)
 def _load_cached_model_objects(
     checkpoint_paths: tuple[str, ...],
@@ -390,7 +441,13 @@ def run_inprocess_prediction_pipeline(
 ) -> str:
     parameter = _validate_parameter(request.parameter)
     paths = prepare_prediction_inputs(parameter, request.input_file, request.repo_root)
-    run_inprocess_prediction(request, paths)
+    if request.protein_records_file:
+        prediction_paths, was_deduplicated = paths, False
+    else:
+        prediction_paths, was_deduplicated = _deduplicate_prediction_input(paths)
+    run_inprocess_prediction(request, prediction_paths)
+    if was_deduplicated:
+        _expand_deduplicated_prediction_output(paths, prediction_paths)
     return _write_postprocessed_predictions(parameter, paths, request.repo_root, results_dir)
 
 

--- a/tests/test_esm_batching.py
+++ b/tests/test_esm_batching.py
@@ -1,0 +1,118 @@
+import importlib.util
+import unittest
+from unittest.mock import patch
+
+
+def _has_module(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ValueError:
+        return False
+
+
+HAS_DATA_DEPS = all(_has_module(name) for name in ("numpy", "pandas", "rdkit", "torch"))
+HAS_ESM_DEPS = HAS_DATA_DEPS and _has_module("esm")
+
+
+@unittest.skipUnless(HAS_DATA_DEPS, "CatPred data dependencies are required")
+class PopulateMissingEsmFeaturesTests(unittest.TestCase):
+    def test_uses_batch_getter_once_for_unique_missing_sequences(self) -> None:
+        from catpred.data import utils
+
+        records = [
+            {"name": "protein_a", "seq": "AAA"},
+            {"name": "protein_b", "seq": "BBB"},
+            {"name": "protein_c", "seq": "AAA"},
+        ]
+        calls = []
+
+        def batch_getter(sequences, device):
+            calls.append((list(sequences), device))
+            return {sequence: f"features-{sequence}" for sequence in sequences}
+
+        utils._populate_missing_esm2_features(
+            records,
+            sequence_feat_getter=None,
+            sequence_batch_getter=batch_getter,
+        )
+
+        self.assertEqual(calls, [(["AAA", "BBB"], "cpu")])
+        self.assertEqual(records[0]["esm2_feats"], "features-AAA")
+        self.assertEqual(records[1]["esm2_feats"], "features-BBB")
+        self.assertEqual(records[2]["esm2_feats"], "features-AAA")
+
+    def test_fallback_getter_deduplicates_sequences(self) -> None:
+        from catpred.data import utils
+
+        records = [
+            {"name": "protein_a", "seq": "AAA"},
+            {"name": "protein_b", "seq": "BBB"},
+            {"name": "protein_c", "seq": "AAA"},
+        ]
+        calls = []
+
+        def single_getter(sequence, name, device):
+            calls.append((sequence, name, device))
+            return ([f"features-{sequence}"], None)
+
+        utils._populate_missing_esm2_features(
+            records,
+            sequence_feat_getter=single_getter,
+            sequence_batch_getter=None,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                ("AAA", "protein_a", "cpu"),
+                ("BBB", "protein_b", "cpu"),
+            ],
+        )
+        self.assertEqual(records[0]["esm2_feats"], "features-AAA")
+        self.assertEqual(records[1]["esm2_feats"], "features-BBB")
+        self.assertEqual(records[2]["esm2_feats"], "features-AAA")
+
+
+@unittest.skipUnless(HAS_ESM_DEPS, "ESM and torch dependencies are required")
+class BatchedEsmCacheTests(unittest.TestCase):
+    def test_get_many_esm_reprs_skips_cached_and_batches_unique_sequences(self) -> None:
+        import torch
+
+        from catpred.data import esm_utils
+
+        cached = {"AAA": torch.tensor([[1.0]])}
+        saved = []
+        batch_calls = []
+
+        def fake_load(path, cache_key, purpose, map_location):
+            return cached.get(cache_key)
+
+        def fake_save(value, path, cache_key):
+            saved.append((cache_key, value.detach().cpu().clone()))
+
+        def fake_batch(sequences):
+            batch_calls.append(list(sequences))
+            return [torch.tensor([[float(index + 2)]]) for index, _ in enumerate(sequences)]
+
+        with patch("catpred.data.esm_utils.load_cache_value", side_effect=fake_load), patch(
+            "catpred.data.esm_utils.save_cache_value", side_effect=fake_save
+        ), patch(
+            "catpred.data.esm_utils._run_esm_batch_with_fallback",
+            side_effect=fake_batch,
+        ):
+            result = esm_utils.get_many_esm_reprs(
+                ["AAA", "BBB", "CCC", "BBB"],
+                device="cpu",
+                batch_size=2,
+            )
+
+        self.assertEqual(batch_calls, [["BBB", "CCC"]])
+        self.assertEqual([key for key, _ in saved], ["BBB", "CCC"])
+        self.assertEqual(set(result), {"AAA", "BBB", "CCC"})
+        self.assertTrue(torch.equal(result["AAA"], torch.tensor([[1.0]])))
+        self.assertTrue(torch.equal(result["BBB"], torch.tensor([[2.0]])))
+        self.assertTrue(torch.equal(result["CCC"], torch.tensor([[3.0]])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inference_fast_path.py
+++ b/tests/test_inference_fast_path.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 import types
 import unittest
@@ -8,12 +9,14 @@ from unittest.mock import patch
 
 
 def install_import_stubs() -> None:
-    pandas = types.ModuleType("pandas")
-    pandas.DataFrame = object
-    sys.modules.setdefault("pandas", pandas)
+    if importlib.util.find_spec("pandas") is None:
+        pandas = types.ModuleType("pandas")
+        pandas.DataFrame = object
+        sys.modules.setdefault("pandas", pandas)
 
-    numpy = types.ModuleType("numpy")
-    sys.modules.setdefault("numpy", numpy)
+    if importlib.util.find_spec("numpy") is None:
+        numpy = types.ModuleType("numpy")
+        sys.modules.setdefault("numpy", numpy)
 
     rdkit = types.ModuleType("rdkit")
     chem = types.ModuleType("rdkit.Chem")
@@ -136,6 +139,59 @@ class ModelCacheTests(unittest.TestCase):
         self.assertEqual(second[2], ["model"])
         self.assertEqual(first_args.updated_from, "train_args")
         self.assertEqual(second_args.updated_from, "train_args")
+
+
+class PredictionInputDeduplicationTests(unittest.TestCase):
+    def test_duplicate_inputs_are_expanded_back_to_original_rows(self) -> None:
+        if not hasattr(service.pd, "read_csv"):
+            self.skipTest("pandas is stubbed in this test environment")
+
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            input_csv = tmp_path / "input.csv"
+            records_file = tmp_path / "input.json.gz"
+            output_csv = tmp_path / "input_output.csv"
+            input_csv.write_text(
+                "\n".join(
+                    [
+                        "Substrate,SMILES,sequence,pdbpath",
+                        "first,C,AAAA,seq1.pdb",
+                        "second,C,AAAA,seq1-copy.pdb",
+                        "third,O,BBBB,seq2.pdb",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            paths = service.PreparedInputPaths(
+                input_csv=str(input_csv),
+                records_file=str(records_file),
+                output_csv=str(output_csv),
+            )
+
+            deduplicated_paths, was_deduplicated = service._deduplicate_prediction_input(paths)
+            self.assertTrue(was_deduplicated)
+
+            unique_output = Path(deduplicated_paths.output_csv)
+            unique_output.write_text(
+                "\n".join(
+                    [
+                        "Substrate,SMILES,sequence,pdbpath,log10kcat_max,log10kcat_max_mve_uncal_var",
+                        "first,C,AAAA,seq1.pdb,1.0,0.1",
+                        "third,O,BBBB,seq2.pdb,2.0,0.2",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            service._expand_deduplicated_prediction_output(paths, deduplicated_paths)
+            expanded_lines = output_csv.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(len(expanded_lines), 4)
+        self.assertIn("first,C,AAAA,seq1.pdb,1.0,0.1", expanded_lines)
+        self.assertIn("second,C,AAAA,seq1-copy.pdb,1.0,0.1", expanded_lines)
+        self.assertIn("third,O,BBBB,seq2.pdb,2.0,0.2", expanded_lines)
 
 
 class FastPredictArgsTests(unittest.TestCase):

--- a/tests/test_inference_fast_path.py
+++ b/tests/test_inference_fast_path.py
@@ -163,6 +163,7 @@ class PredictionInputDeduplicationTests(unittest.TestCase):
                 + "\n",
                 encoding="utf-8",
             )
+
             paths = service.PreparedInputPaths(
                 input_csv=str(input_csv),
                 records_file=str(records_file),
@@ -192,6 +193,70 @@ class PredictionInputDeduplicationTests(unittest.TestCase):
         self.assertIn("first,C,AAAA,seq1.pdb,1.0,0.1", expanded_lines)
         self.assertIn("second,C,AAAA,seq1-copy.pdb,1.0,0.1", expanded_lines)
         self.assertIn("third,O,BBBB,seq2.pdb,2.0,0.2", expanded_lines)
+
+
+class PredictionResultCacheTests(unittest.TestCase):
+    def setUp(self) -> None:
+        service._PREDICTION_CACHE.clear()
+
+    def tearDown(self) -> None:
+        service._PREDICTION_CACHE.clear()
+
+    def test_pipeline_reuses_cached_prediction_for_identical_request(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            input_csv = repo_root / "prepared.csv"
+            input_csv.write_text("SMILES,sequence\nC,AAAA\n", encoding="utf-8")
+            records_file = repo_root / "prepared.json.gz"
+            records_file.write_bytes(b"records")
+            output_csv = repo_root / "prepared_output.csv"
+            checkpoint = repo_root / "checkpoints" / "fold_0" / "model_0" / "model.pt"
+            checkpoint.parent.mkdir(parents=True)
+            checkpoint.write_bytes(b"checkpoint")
+
+            paths = service.PreparedInputPaths(
+                input_csv=str(input_csv),
+                records_file=str(records_file),
+                output_csv=str(output_csv),
+            )
+            request = PredictionRequest(
+                parameter="kcat",
+                input_file=str(input_csv),
+                checkpoint_dir=str(checkpoint.parent.parent.parent),
+                repo_root=str(repo_root),
+            )
+
+            def write_final(parameter, prepared_paths, repo_root_arg, results_dir):
+                final_output = Path(results_dir) / Path(prepared_paths.output_csv).name
+                final_output.parent.mkdir(parents=True, exist_ok=True)
+                final_output.write_text("SMILES,kcat\nC,1.23\n", encoding="utf-8")
+                return str(final_output)
+
+            with patch(
+                "catpred.inference.service.prepare_prediction_inputs",
+                return_value=paths,
+            ), patch(
+                "catpred.inference.service.run_inprocess_prediction",
+            ) as runner, patch(
+                "catpred.inference.service._write_postprocessed_predictions",
+                side_effect=write_final,
+            ) as postprocess:
+                first = service.run_inprocess_prediction_pipeline(
+                    request,
+                    results_dir=str(repo_root / "results" / "first"),
+                )
+                second = service.run_inprocess_prediction_pipeline(
+                    request,
+                    results_dir=str(repo_root / "results" / "second"),
+                )
+                first_text = Path(first).read_text(encoding="utf-8")
+                second_text = Path(second).read_text(encoding="utf-8")
+
+        runner.assert_called_once()
+        postprocess.assert_called_once()
+        self.assertEqual(first_text, "SMILES,kcat\nC,1.23\n")
+        self.assertEqual(second_text, "SMILES,kcat\nC,1.23\n")
+        self.assertNotEqual(first, second)
 
 
 class FastPredictArgsTests(unittest.TestCase):

--- a/tests/test_postprocess_predictions.py
+++ b/tests/test_postprocess_predictions.py
@@ -19,6 +19,8 @@ HAS_PANDAS_NUMPY = _has_module("pandas") and _has_module("numpy")
 @unittest.skipUnless(HAS_PANDAS_NUMPY, "pandas and numpy are required")
 class PostprocessPredictionTests(unittest.TestCase):
     def setUp(self) -> None:
+        if _has_module("rdkit"):
+            return
         rdkit = types.ModuleType("rdkit")
         chem = types.ModuleType("rdkit.Chem")
         rdkit.Chem = chem


### PR DESCRIPTION
## Summary
- Stacked on #42 (`Batch uncached ESM embeddings`); after #42 merges this branch can be rebased so reviewers see only the final two performance commits.
- Deduplicate repeated `(SMILES, sequence)` rows inside a single in-process inference request, run the model once per unique pair, then expand predictions back to the original row order.
- Add an in-memory LRU cache for completed in-process prediction CSVs keyed by parameter, GPU mode, prepared input digest, optional protein-record digest, and checkpoint fingerprint.
- Keep the custom `protein_records_file` path conservative by skipping intra-request dedupe when external records are supplied.

## Benchmark Highlights
- `kcat`, 100 duplicate-heavy rows, local CPU warm in-process: `15.7528s` baseline -> `0.00893s` combined branch after warmup.
- Dedupe-only larger local CPU checks: `kcat` 20 rows `3.4179s -> 0.3193s`; `kcat` 100 rows `15.7528s -> 0.3347s`; `km` 20 rows `3.3655s -> 0.3225s`; `ki` 20 rows `0.7576s -> 0.0670s`.
- Result-cache repeated-request checks: `kcat` 100 rows `15.7528s -> 0.00978s`; `km` 2 rows `0.3042s -> 0.00183s`; `ki` 2 rows `0.0614s -> 0.00159s`.
- Rejected trials below the 5% threshold: `TQDM_DISABLE=1`, BLAS/thread limiting, checkpoint-stat monkeypatch removal, and larger prediction batch size.

## Modal GPU Verification
- Verified on Modal Tesla T4 with the pushed branch and cached Modal checkpoints.
- `kcat` 100 duplicate-heavy rows: median remote-call timing `0.482s`, row_count `100`, deduped to `Test size = 2`.
- `km` 20 duplicate-heavy rows: median `0.604s`, row_count `20`, deduped to `Test size = 2`.
- `ki` 20 duplicate-heavy rows: median `0.310s`, row_count `20`, deduped to `Test size = 1`.

## Correctness / Tests
- `conda run -n esm python -m unittest tests.test_inference_fast_path`
- `git diff --check`
- Local output comparisons preserved predictions for `kcat`, `km`, and `ki`; duplicate-expanded outputs matched baseline with max absolute differences under `1e-6` where floating formatting differed.
